### PR TITLE
Workshop july

### DIFF
--- a/source/BlueNRGDevice.cpp
+++ b/source/BlueNRGDevice.cpp
@@ -181,11 +181,9 @@ ble_error_t BlueNRGDevice::init(BLE::InstanceID_t instanceID, FunctionPointerWit
         	callback.call(&context);
         	return BLE_ERROR_ALREADY_INITIALIZED;
     	}
-	
-	/* ToDo: Clear memory contents, reset the SD, etc. */
+
 	// Init the BlueNRG/BlueNRG-MS stack
-	// By default, we set the device GAP role to PERIPHERAL
-	btleInit(BlueNRGGap::getInstance().getIsSetAddress(), GAP_PERIPHERAL_ROLE_IDB04A1);
+	btleInit();
 	
 	isInitialized = true;
 	BLE::InitializationCompleteCallbackContext context = {

--- a/source/BlueNRGDiscoveredCharacteristic.cpp
+++ b/source/BlueNRGDiscoveredCharacteristic.cpp
@@ -62,3 +62,7 @@ void BlueNRGDiscoveredCharacteristic::setup(BlueNRGGattClient         *gattcIn,
     props._indicate        = propsIn.indicate();
     props._authSignedWrite = propsIn.authSignedWrite();
 }
+
+ void BlueNRGDiscoveredCharacteristic::setLastHandle(GattAttribute::Handle_t  lastHandleIn) {
+     lastHandle = lastHandleIn;
+ }

--- a/source/BlueNRGGap.cpp
+++ b/source/BlueNRGGap.cpp
@@ -501,9 +501,9 @@ ble_error_t BlueNRGGap::startAdvertising(const GapAdvertisingParams &params)
     );
 
     if (err) {
-        printf("impossible to set advertising parameters\n\r");
-        printf("advInterval min: %u, advInterval max: %u\n\r", advInterval, advInterval + 1);
-        printf("advType: %u, advFilterPolicy: %u\n\r", params.getAdvertisingType(), advFilterPolicy);
+        PRINTF("impossible to set advertising parameters\n\r");
+        PRINTF("advInterval min: %u, advInterval max: %u\n\r", advInterval, advInterval + 1);
+        PRINTF("advType: %u, advFilterPolicy: %u\n\r", params.getAdvertisingType(), advFilterPolicy);
         return BLE_ERROR_INVALID_PARAM;
     }
 
@@ -1352,7 +1352,7 @@ void BlueNRGGap::setAdvParameters(void)
     advIntMS = (conn_min_interval*1.25)-GUARD_INT;
     advInterval = _advParams.MSEC_TO_ADVERTISEMENT_DURATION_UNITS(advIntMS);
 
-    printf("conn_min_interval is equal to %u\r\n", conn_min_interval);
+    PRINTF("conn_min_interval is equal to %u\r\n", conn_min_interval);
   } else {
     advInterval = _advParams.getIntervalInADVUnits();
   }

--- a/source/BlueNRGGap.cpp
+++ b/source/BlueNRGGap.cpp
@@ -275,7 +275,7 @@ ble_error_t BlueNRGGap::setAdvertisingData(const GapAdvertisingData &advData, co
 
             case GapAdvertisingData::ADVERTISING_INTERVAL:               /**< Advertising Interval */
                 {
-                printf("Advertising type: ADVERTISING_INTERVAL\n\r");
+                PRINTF("Advertising type: ADVERTISING_INTERVAL\n\r");
                 uint8_t buffSize = *loadPtr.getUnitAtIndex(index).getLenPtr()-1;
                 AdvData[AdvLen++] = buffSize+1; // the fisrt byte is the data buffer size (type+data)
                 AdvData[AdvLen++] = AD_TYPE_ADVERTISING_INTERVAL;
@@ -323,7 +323,7 @@ ble_error_t BlueNRGGap::setAdvertisingData(const GapAdvertisingData &advData, co
     int err = hci_le_set_advertising_data(advData.getPayloadLen(), advData.getPayload());
 
     if (err) {
-        printf("error while setting the payload\r\n");
+        PRINTF("error while setting the payload\r\n");
         return BLE_ERROR_UNSPECIFIED;
     }
 
@@ -501,9 +501,9 @@ ble_error_t BlueNRGGap::startAdvertising(const GapAdvertisingParams &params)
     );
 
     if (err) {
-        PRINTF("impossible to set advertising parameters\n\r");
-        PRINTF("advInterval min: %u, advInterval max: %u\n\r", advInterval, advInterval + 1);
-        PRINTF("advType: %u, advFilterPolicy: %u\n\r", params.getAdvertisingType(), advFilterPolicy);
+        printf("impossible to set advertising parameters\n\r");
+        printf("advInterval min: %u, advInterval max: %u\n\r", advInterval, advInterval + 1);
+        printf("advType: %u, advFilterPolicy: %u\n\r", params.getAdvertisingType(), advFilterPolicy);
         return BLE_ERROR_INVALID_PARAM;
     }
 
@@ -1351,6 +1351,8 @@ void BlueNRGGap::setAdvParameters(void)
   if(state.connected == 1) {
     advIntMS = (conn_min_interval*1.25)-GUARD_INT;
     advInterval = _advParams.MSEC_TO_ADVERTISEMENT_DURATION_UNITS(advIntMS);
+
+    printf("conn_min_interval is equal to %u\r\n", conn_min_interval);
   } else {
     advInterval = _advParams.getIntervalInADVUnits();
   }
@@ -1565,4 +1567,9 @@ ble_error_t BlueNRGGap::reset(void)
     scanningPolicyMode    = Gap::SCAN_POLICY_IGNORE_WHITELIST;
 
     return BLE_ERROR_NONE;
+}
+
+void BlueNRGGap::setConnectionInterval(uint16_t interval) {
+    conn_min_interval = interval;
+    conn_max_interval = interval;
 }

--- a/source/BlueNRGGattClient.cpp
+++ b/source/BlueNRGGattClient.cpp
@@ -15,7 +15,7 @@
 */
 /**
   ******************************************************************************
-  * @file    BlueNRGGattServer.cpp 
+  * @file    BlueNRGGattServer.cpp
   * @author  STMicroelectronics
   * @brief   Implementation of BlueNRG BLE_API GattServer Class
   ******************************************************************************
@@ -29,13 +29,13 @@
   * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
   *
   * <h2><center>&copy; COPYRIGHT 2013 STMicroelectronics</center></h2>
-  */ 
- 
+  */
+
 /** @defgroup BlueNRGGATTClient
  *  @brief BlueNRG BLE_API GattClient Adaptation
  *  @{
  */
- 
+
 #include "BlueNRGGattClient.h"
 #include "mbed-drivers/mbed.h"
 #include "BlueNRGGap.h"
@@ -59,10 +59,10 @@ void BlueNRGGattClient::gattProcedureCompleteCB(Gap::Handle_t connectionHandle, 
     _currentState = GATT_IDLE;
     return;
   }
-    
+
   // Service Discovery complete
 /*
-  if(_currentState != GATT_IDLE && 
+  if(_currentState != GATT_IDLE &&
      _currentState != GATT_DISCOVERY_TERMINATED &&
      _currentState != GATT_WRITE_CHAR &&
      _currentState != GATT_READ_CHAR) {
@@ -86,7 +86,7 @@ void BlueNRGGattClient::gattProcedureCompleteCB(Gap::Handle_t connectionHandle, 
     _currentState = GATT_IDLE;
   }
 }
-                                                
+
 void BlueNRGGattClient::primaryServicesCB(Gap::Handle_t connectionHandle,
                                           uint8_t event_data_length,
                                           uint8_t attribute_data_length,
@@ -107,13 +107,13 @@ void BlueNRGGattClient::primaryServicesCB(Gap::Handle_t connectionHandle,
 
     // UUID Type
     if (attribute_data_length == 6) {
-      
+
       PRINTF("UUID_TYPE_16\n\r");
       uuid = attribute_data_list[offset+5]<<8|attribute_data_list[offset+4];
       PRINTF("S UUID-%X attrs[%u %u]\r\n", uuid.getShortUUID(), startHandle, endHandle);
-      
+
     } else {
-      
+
       PRINTF("UUID_TYPE_128\n\r");
       uuid.setupLong(attribute_data_list+offset+4, UUID::LSB);
 
@@ -125,17 +125,12 @@ void BlueNRGGattClient::primaryServicesCB(Gap::Handle_t connectionHandle,
       }
 #endif
       PRINTF(" attrs[%u %u]\r\n", startHandle, endHandle);
-      
+
     }
-    
+
     PRINTF("Setup serviceIndex = %d\n\r", _numServices);
     discoveredService[_numServices].setup(uuid, startHandle, endHandle);
-    
-    if(serviceDiscoveryCallback) {
-      if(_matchingServiceUUID == BLE_UUID_UNKNOWN || _matchingServiceUUID == discoveredService[_numServices].getUUID()) {
-        serviceDiscoveryCallback(&discoveredService[_numServices]);
-      }
-    }
+
     _numServices++;
 
     offset += attribute_data_length;
@@ -181,12 +176,9 @@ void BlueNRGGattClient::primaryServiceCB(Gap::Handle_t connectionHandle,
     }
 
     discoveredService[i].setup(uuid, startHandle, endHandle);
-    
-    if(serviceDiscoveryCallback) {
-      serviceDiscoveryCallback(&discoveredService[_numServices]);
-    }
+
     _numServices++;
-    
+
     offset += 4;
   }
 }
@@ -225,10 +217,10 @@ void BlueNRGGattClient::serviceCharsCB(Gap::Handle_t connectionHandle,
       PRINTF("\r\n");
 #endif
     }
-    
+
     // Properties
     DiscoveredCharacteristic::Properties_t p;
-    
+
     p._broadcast = (props_mask[0] & handle_value_pair[offset+2]);
     p._read = (props_mask[1] & handle_value_pair[offset+2])>>1;
     p._writeWoResp = (props_mask[2] & handle_value_pair[offset+2])>>2;
@@ -263,9 +255,14 @@ void BlueNRGGattClient::serviceCharsCB(Gap::Handle_t connectionHandle,
                                     valueHandle,
                                     lastHandle);
 
-    if(characteristicDiscoveryCallback) {
-      characteristicDiscoveryCallback(&discoveredChar[_numChars]);
+    if (_numChars != 0) {
+        discoveredChar[_numChars - 1].setLastHandle(declHandle - 1);
+
+        if(characteristicDiscoveryCallback) {
+          characteristicDiscoveryCallback(&discoveredChar[_numChars - 1]);
+        }
     }
+
     _numChars++;
 
     offset += handle_value_pair_length;
@@ -280,9 +277,9 @@ void BlueNRGGattClient::serviceCharByUUIDCB(Gap::Handle_t connectionHandle,
   // Charac Properties(1), Charac Value Handle(2), Charac UUID(2/16)
   GattAttribute::Handle_t declHandle, valueHandle, lastHandle;
   UUID uuid;
-  
+
   PRINTF("serviceCharByUUIDCB\n\r");
-  
+
   // UUID Type
   if (event_data_length == 7) {
     PRINTF("Char UUID_TYPE_16\n\r");
@@ -303,7 +300,7 @@ void BlueNRGGattClient::serviceCharByUUIDCB(Gap::Handle_t connectionHandle,
 
   // Properties
   DiscoveredCharacteristic::Properties_t p;
-  
+
   p._broadcast = (props_mask[0] & attr_value[0]);
   p._read = (props_mask[1] & attr_value[0])>>1;
   p._writeWoResp = (props_mask[2] & attr_value[0])>>2;
@@ -336,7 +333,7 @@ void BlueNRGGattClient::serviceCharByUUIDCB(Gap::Handle_t connectionHandle,
                                   declHandle,
                                   valueHandle,
                                   lastHandle);
-  
+
   if(characteristicDiscoveryCallback) {
     characteristicDiscoveryCallback(&discoveredChar[_numChars]);
   }
@@ -346,24 +343,37 @@ void BlueNRGGattClient::serviceCharByUUIDCB(Gap::Handle_t connectionHandle,
 ble_error_t BlueNRGGattClient::findServiceChars(Gap::Handle_t connectionHandle)
 {
   PRINTF("findServiceChars\n\r");
-  
+
   tBleStatus ret;
   uint8_t uuid_type = UUID_TYPE_16;
   uint8_t short_uuid[2];
   uint8_t *uuid = NULL;
-  
+
   DiscoveredService *service;
-  
+
+  // complete the discovery of the last characteristic of the previous service.
+  // Its last handle wasn't known before this point
+  // update the handle and call the characteristic discovery callback.
+  if (_servIndex != 0 && _numChars != 0) {
+      discoveredChar[_numChars - 1].setLastHandle(discoveredService[_servIndex - 1].getEndHandle());
+
+      if(characteristicDiscoveryCallback) {
+        characteristicDiscoveryCallback(&discoveredChar[_numChars - 1]);
+      }
+  }
+
+  _numChars = 0;
+
   // We finished chars discovery for all services
   if(_servIndex >= _numServices) {
     PRINTF("!!!We finished chars discovery for all services!!!\n\r");
     //_currentState = GATT_CHARS_DISCOVERY_COMPLETE;
-    
+
     terminateServiceDiscovery();
-    
+
     return BLE_ERROR_NONE;
   }
-    
+
   service = &discoveredService[_servIndex];
   /*
   if (service->getUUID().shortOrLong() == UUID::UUID_TYPE_SHORT) {
@@ -377,55 +387,59 @@ ble_error_t BlueNRGGattClient::findServiceChars(Gap::Handle_t connectionHandle)
     PRINTF("\r\n");
   }
   */
-  
+
+  if(serviceDiscoveryCallback) {
+    serviceDiscoveryCallback(service);
+  }
+
   PRINTF("findServiceChars (_servIndex=%d)\n\r", _servIndex);
   //ret = aci_gatt_disc_all_charac_of_serv(connectionHandle, service->getStartHandle(), service->getEndHandle());
 
-  if(_matchingCharacteristicUUIDIn == BLE_UUID_UNKNOWN) {
-    PRINTF("findServiceChars (BLE_UUID_UNKNOWN)\n\r");
-    ret = aci_gatt_disc_all_charac_of_serv(connectionHandle, service->getStartHandle(), service->getEndHandle());
-  } else {
-    
-    uint8_t type = _matchingCharacteristicUUIDIn.shortOrLong();
-    
-    if(type == UUID::UUID_TYPE_SHORT) {
-      STORE_LE_16(short_uuid, _matchingCharacteristicUUIDIn.getShortUUID());
-      
-      uuid_type = UUID_TYPE_16;
-      uuid = short_uuid;
+    if(_matchingCharacteristicUUIDIn == BLE_UUID_UNKNOWN) {
+        PRINTF("findServiceChars (BLE_UUID_UNKNOWN)\n\r");
+        ret = aci_gatt_disc_all_charac_of_serv(connectionHandle, service->getStartHandle(), service->getEndHandle());
+    } else {
+
+        uint8_t type = _matchingCharacteristicUUIDIn.shortOrLong();
+
+        if(type == UUID::UUID_TYPE_SHORT) {
+            STORE_LE_16(short_uuid, _matchingCharacteristicUUIDIn.getShortUUID());
+
+            uuid_type = UUID_TYPE_16;
+            uuid = short_uuid;
 #ifdef DEBUG
-      PRINTF("findServiceChars C UUID-");
-      for(unsigned i = 0; i < 2; i++) {
-        PRINTF("%02X", short_uuid[i]);
-      }
-      PRINTF("\n\r");
+            PRINTF("findServiceChars C UUID-");
+            for(unsigned i = 0; i < 2; i++) {
+                PRINTF("%02X", short_uuid[i]);
+            }
+            PRINTF("\n\r");
 #endif
-    } else if(type==UUID::UUID_TYPE_LONG) {
-      
-      uuid_type = UUID_TYPE_128;
-      uuid = (unsigned char*)_matchingCharacteristicUUIDIn.getBaseUUID();
+        } else if(type==UUID::UUID_TYPE_LONG) {
+
+            uuid_type = UUID_TYPE_128;
+            uuid = (unsigned char*)_matchingCharacteristicUUIDIn.getBaseUUID();
 #ifdef DEBUG
-      PRINTF("(findServiceChars) C UUID-");
-      for (unsigned i = 0; i < UUID::LENGTH_OF_LONG_UUID; i++) {
-        PRINTF("%02X", uuid[i]);
-      }
-      PRINTF("\r\n");
+            PRINTF("(findServiceChars) C UUID-");
+            for (unsigned i = 0; i < UUID::LENGTH_OF_LONG_UUID; i++) {
+                PRINTF("%02X", uuid[i]);
+            }
+            PRINTF("\r\n");
 #endif
+        }
+
+        ret = aci_gatt_disc_charac_by_uuid(connectionHandle,
+                                           service->getStartHandle(),
+                                           service->getEndHandle(),
+                                           uuid_type,
+                                           uuid);
     }
 
-    ret = aci_gatt_disc_charac_by_uuid(connectionHandle,
-                                       service->getStartHandle(),
-                                       service->getEndHandle(),
-                                       uuid_type,
-                                       uuid);
-  }
-  
   if(ret == BLE_STATUS_SUCCESS) {
     _servIndex++;
   }
-  
+
   PRINTF("findServiceChars ret=%d\n\r", ret);
-  
+
   return BLE_ERROR_NONE;
 }
 
@@ -436,7 +450,7 @@ ble_error_t BlueNRGGattClient::launchServiceDiscovery(Gap::Handle_t             
                                                       const UUID                                 &matchingCharacteristicUUIDIn)
 {
   PRINTF("launchServiceDiscovery\n\r");
-  
+
   tBleStatus ret;
   uint8_t uuid_type = UUID_TYPE_16;
   uint8_t short_uuid[2];
@@ -466,17 +480,17 @@ ble_error_t BlueNRGGattClient::launchServiceDiscovery(Gap::Handle_t             
   for(j = 0; j < BLE_TOTAL_DISCOVERED_SERVICES; j++) {
     discoveredService[j].setup(BLE_UUID_UNKNOWN, GattAttribute::INVALID_HANDLE, GattAttribute::INVALID_HANDLE);
   }
-  
+
   if(matchingServiceUUID == BLE_UUID_UNKNOWN) {
-    
+
     // Wildcard: search for all services
     ret = aci_gatt_disc_all_prim_services((uint16_t)connectionHandle);
-    
+
   } else {
-  
+
     uint8_t type = matchingServiceUUID.shortOrLong();
     //PRINTF("AddService(): Type:%d\n\r", type);
-    
+
     if(type == UUID::UUID_TYPE_SHORT) {
       STORE_LE_16(short_uuid, matchingServiceUUID.getShortUUID());
 #ifdef DEBUG
@@ -486,10 +500,10 @@ ble_error_t BlueNRGGattClient::launchServiceDiscovery(Gap::Handle_t             
       }
       PRINTF("\n\r");
 #endif
-      
+
       uuid_type = UUID_TYPE_16;
       uuid = short_uuid;
-      
+
     } else if(type==UUID::UUID_TYPE_LONG) {
 
       uuid_type = UUID_TYPE_128;
@@ -503,18 +517,18 @@ ble_error_t BlueNRGGattClient::launchServiceDiscovery(Gap::Handle_t             
       PRINTF("\n\r");
 #endif
     }
-    
+
     // search for specific service by UUID
     ret = aci_gatt_disc_prim_service_by_uuid((uint16_t)connectionHandle, uuid_type, uuid);
     //ret = aci_gatt_disc_all_prim_services((uint16_t)connectionHandle);
   }
-    
+
   if(ret == BLE_STATUS_SUCCESS) {
     _currentState = GATT_SERVICE_DISCOVERY;
   }
-  
+
   PRINTF("launchServiceDiscovery ret=%d\n\r", ret);
-  
+
   return BLE_ERROR_NONE;
 }
 
@@ -558,7 +572,7 @@ bool BlueNRGGattClient::isServiceDiscoveryActive(void) const
          _currentState == GATT_WRITE_CHAR ) {
     return false;
   }
-  
+
   return true;
 */
 }
@@ -566,7 +580,7 @@ bool BlueNRGGattClient::isServiceDiscoveryActive(void) const
 void BlueNRGGattClient::terminateServiceDiscovery(void)
 {
   _currentState = GATT_IDLE;//GATT_DISCOVERY_TERMINATED;
-  
+
   if (terminationCallback) {
     terminationCallback(_connectionHandle);
   }
@@ -590,18 +604,18 @@ ble_error_t BlueNRGGattClient::read(Gap::Handle_t connHandle, GattAttribute::Han
   (void)offset;
 
   tBleStatus ret;
-  
+
   BlueNRGGattClient *gattc = const_cast<BlueNRGGattClient*>(this);
-  
-  // Save the attribute_handle not provided by evt_att_read_resp    
+
+  // Save the attribute_handle not provided by evt_att_read_resp
   gattc->readCBParams.handle = attributeHandle;
-  
+
   // FIXME: We need to wait for a while before starting a read
   // due to BlueNRG process queue handling
   Clock_Wait(100);
 
   ret = aci_gatt_read_charac_val(connHandle, attributeHandle);
-  
+
   if(ret == BLE_STATUS_SUCCESS) {
     gattc->_currentState = GATT_READ_CHAR;
     return BLE_ERROR_NONE;
@@ -639,7 +653,7 @@ void BlueNRGGattClient::charWriteExecCB(Gap::Handle_t connHandle,
   (void)event_data_length;
 
   writeCBParams.connHandle = connHandle;
-  
+
   BlueNRGGattClient::getInstance().processWriteResponse(&writeCBParams);
 }
 
@@ -653,9 +667,9 @@ ble_error_t BlueNRGGattClient::write(GattClient::WriteOp_t    cmd,
   (void)cmd;
 
   tBleStatus ret;
-  
+
   BlueNRGGattClient *gattc = const_cast<BlueNRGGattClient*>(this);
-  
+
   // We save the write response params (used by the callback) because
   // when the aci_gatt_write_charac_value() is used the only event received is the EVT_BLUE_GATT_PROCEDURE_COMPLETE
   gattc->writeCBParams.connHandle = connHandle;
@@ -664,10 +678,10 @@ ble_error_t BlueNRGGattClient::write(GattClient::WriteOp_t    cmd,
   gattc->writeCBParams.offset = 0;
   gattc->writeCBParams.len = length;
   gattc->writeCBParams.data = value;
-  
+
   ret = aci_gatt_write_charac_value(connHandle, attributeHandle, length, const_cast<uint8_t *>(value));
   //ret = aci_gatt_write_charac_reliable(connHandle, attributeHandle, 0, length, const_cast<uint8_t *>(value));
-  
+
   if (ret == BLE_STATUS_SUCCESS) {
     gattc->_currentState = GATT_WRITE_CHAR;
     return BLE_ERROR_NONE;
@@ -694,7 +708,7 @@ void BlueNRGGattClient::discAllCharacDescCB(Gap::Handle_t connHandle,
     handle_uuid_length = 18; //Handle + UUID_128
 
   numCharacDesc = (event_data_length - 1) / handle_uuid_length;
-  
+
   offset = 0;
 
   for (i=0; i<numCharacDesc; i++) {
@@ -702,13 +716,13 @@ void BlueNRGGattClient::discAllCharacDescCB(Gap::Handle_t connHandle,
 
     // UUID Type
     if (handle_uuid_length == 4) {
-      
+
       PRINTF("UUID_TYPE_16\n\r");
       uuid = handle_uuid_pair[offset+3]<<8|handle_uuid_pair[offset+2];
       PRINTF("D UUID-%X attHandle=%u\r\n", uuid.getShortUUID(), attHandle);
-      
+
     } else {
-      
+
       PRINTF("UUID_TYPE_128\n\r");
       uuid.setupLong(handle_uuid_pair+offset+2, UUID::LSB);
 #ifdef DEBUG
@@ -813,4 +827,3 @@ ble_error_t BlueNRGGattClient::reset(void) {
 
   return BLE_ERROR_NONE;
 }
-

--- a/source/BlueNRGGattServer.cpp
+++ b/source/BlueNRGGattServer.cpp
@@ -176,7 +176,7 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
                     (GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE_WITHOUT_RESPONSE|
                         GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE))) {
             PRINTF("Setting up Gatt GATT_NOTIFY_ATTRIBUTE_WRITE Mask\n\r");
-            Gatt_Evt_Mask = Gatt_Evt_Mask | GATT_NOTIFY_WRITE_REQ_AND_WAIT_FOR_APPL_RESP /* | GATT_NOTIFY_ATTRIBUTE_WRITE */;
+            Gatt_Evt_Mask = Gatt_Evt_Mask | GATT_NOTIFY_ATTRIBUTE_WRITE /* | GATT_NOTIFY_WRITE_REQ_AND_WAIT_FOR_APPL_RESP */;
         }
         if((p_char->getProperties() &
                     (GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ|
@@ -440,6 +440,7 @@ ble_error_t BlueNRGGattServer::write(GattAttribute::Handle_t attributeHandle, co
     // check that the len of the data to write are compatible with the characteristic
     GattCharacteristic* characteristic = getCharacteristicFromHandle(attributeHandle);
     if (!characteristic) {
+        printf("characteristic not found\r\n");
         return BLE_ERROR_INVALID_PARAM;
     }
 
@@ -448,12 +449,14 @@ ble_error_t BlueNRGGattServer::write(GattAttribute::Handle_t attributeHandle, co
 
     // reject write if the lenght exceed the maximum lenght of this attribute
     if (value_attribute.getMaxLength() < len) {
+        printf("invalid variable length: %u, max length is: %u\r\n", len, value_attribute.getMaxLength());
         return BLE_ERROR_INVALID_PARAM;
     }
 
     // reject write if the attribute size is fixed and the lenght in input is different than the
     // length of the attribute.
-    if (value_attribute.hasVariableLength() == false && value_attribute.getLength() != len) {
+    if (value_attribute.hasVariableLength() == false && value_attribute.getMaxLength() != len) {
+        printf("invalid fixed length: %u, len should be %u\r\n", len, value_attribute.getMaxLength());
         return BLE_ERROR_INVALID_PARAM;
     }
 

--- a/source/BlueNRGGattServer.cpp
+++ b/source/BlueNRGGattServer.cpp
@@ -15,7 +15,7 @@
 */
 /**
   ******************************************************************************
-  * @file    BlueNRGGattServer.cpp 
+  * @file    BlueNRGGattServer.cpp
   * @author  STMicroelectronics
   * @brief   Implementation of BlueNRG BLE_API GattServer Class
   ******************************************************************************
@@ -30,12 +30,12 @@
   *
   * <h2><center>&copy; COPYRIGHT 2013 STMicroelectronics</center></h2>
   */
- 
+
 /** @defgroup BlueNRGGATTSERVER
  *  @brief BlueNRG BLE_API GattServer Adaptation
  *  @{
  */
- 
+
 #include "BlueNRGGattServer.h"
 #include "mbed-drivers/mbed.h"
 #include "BlueNRGGap.h"
@@ -48,7 +48,7 @@
 
     @params[in] service
                 Pointer to instance of the Gatt Server to add
-                
+
     @returns    ble_error_t
 
     @retval     BLE_ERROR_NONE
@@ -66,7 +66,7 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
     /* ToDo: Make sure we don't overflow the array, etc. */
     /* ToDo: Make sure this service UUID doesn't already exist (?) */
     /* ToDo: Basic validation */
-    
+
     tBleStatus ret;
     uint8_t type;
     uint16_t short_uuid;
@@ -75,20 +75,20 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
     uint8_t char_base_uuid[16];
     const uint8_t *base_uuid;
     const uint8_t *base_char_uuid;
-    
+
     uint8_t charsCount = 0;
     uint8_t maxAttrRecords = 0;
 
     type = (service.getUUID()).shortOrLong();
     PRINTF("AddService(): Type:%d\n\r", type);
-    
+
     /* Add the service to the BlueNRG */
     short_uuid = (service.getUUID()).getShortUUID();
     STORE_LE_16(primary_short_uuid, short_uuid);
-    
+
     if(type==UUID::UUID_TYPE_LONG) {
-        base_uuid = (service.getUUID()).getBaseUUID();   
-        
+        base_uuid = (service.getUUID()).getBaseUUID();
+
         COPY_UUID_128(primary_base_uuid, base_uuid[15],base_uuid[14],primary_short_uuid[1],primary_short_uuid[0],base_uuid[11],base_uuid[10],base_uuid[9],base_uuid[8],base_uuid[7],base_uuid[6],base_uuid[5],base_uuid[4],base_uuid[3],base_uuid[2],base_uuid[1],base_uuid[0]);
     }
 
@@ -112,12 +112,12 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
                                 &servHandle);
         PRINTF("aci_gatt_add_serv UUID_TYPE_LONG ret=%d\n\r", ret);
     }
-    
+
     service.setHandle(servHandle);
     //serviceHandleVector.push_back(servHandle);
     PRINTF("added servHandle handle =%u\n\r", servHandle);
     uint16_t bleCharacteristic;
-    
+
     //iterate to include all characteristics
     for (uint8_t i = 0; i < charsCount; i++) {
         GattCharacteristic *p_char = service.getCharacteristic(i);
@@ -138,7 +138,7 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
 #endif
             COPY_UUID_128(char_base_uuid,base_char_uuid[15],base_char_uuid[14],int_8_uuid[1],int_8_uuid[0],base_char_uuid[11],base_char_uuid[10],base_char_uuid[9],base_char_uuid[8],base_char_uuid[7],base_char_uuid[6],base_char_uuid[5],base_char_uuid[4],base_char_uuid[3],base_char_uuid[2],base_char_uuid[1],base_char_uuid[0]);
         }
-        
+
         PRINTF("Char Properties 0x%x\n\r", p_char->getProperties());
         /*
         * Gatt_Evt_Mask -> HardCoded (0)
@@ -151,13 +151,13 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
                     (GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE_WITHOUT_RESPONSE|
                         GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE))) {
             PRINTF("Setting up Gatt GATT_NOTIFY_ATTRIBUTE_WRITE Mask\n\r");
-            Gatt_Evt_Mask = Gatt_Evt_Mask | GATT_NOTIFY_ATTRIBUTE_WRITE;
+            Gatt_Evt_Mask = Gatt_Evt_Mask | GATT_NOTIFY_WRITE_REQ_AND_WAIT_FOR_APPL_RESP /* | GATT_NOTIFY_ATTRIBUTE_WRITE */;
         }
         if((p_char->getProperties() &
                     (GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ|
                         GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY| GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_INDICATE))) {
             PRINTF("Setting up Gatt GATT_NOTIFY_READ_REQ_AND_WAIT_FOR_APPL_RESP Mask\n\r");
-            Gatt_Evt_Mask = Gatt_Evt_Mask | GATT_NOTIFY_READ_REQ_AND_WAIT_FOR_APPL_RESP; 
+            Gatt_Evt_Mask = Gatt_Evt_Mask | GATT_NOTIFY_READ_REQ_AND_WAIT_FOR_APPL_RESP;
         }    //This will support also GATT_SERVER_ATTR_READ_WRITE since it will be covered by previous if() check.
 
         if(type==UUID::UUID_TYPE_SHORT) {
@@ -171,7 +171,7 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
                                      16 /*Encryption_Key_Size*/,
                                      1 /*isVariable*/,
                                      &bleCharacteristic);
-            
+
             PRINTF("aci_gatt_add_char UUID_TYPE_16 props=%d MaxLength=%d ret=%d\n\r",
                     p_char->getProperties(), p_char->getValueAttribute().getMaxLength(), ret);
 
@@ -186,13 +186,13 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
                                      16 /*Encryption_Key_Size*/,
                                      1 /*isVariable*/,
                                      &bleCharacteristic);
-            
+
             PRINTF("aci_gatt_add_char UUID_TYPE_128 props=%d MaxLength=%d ret=%d\n\r",
                     p_char->getProperties(), p_char->getValueAttribute().getMaxLength(), ret);
         }
-        
+
         bleCharHandleMap.insert(std::pair<uint16_t, uint16_t>(bleCharacteristic, servHandle));
-        
+
         p_characteristics[characteristicCount++] = p_char;
         /* Set the characteristic value handle */
         p_char->getValueAttribute().setHandle(bleCharacteristic+BlueNRGGattServer::CHAR_VALUE_HANDLE);
@@ -207,7 +207,7 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
         // add descriptors now
         uint16_t descHandle = 0;
         PRINTF("p_char->getDescriptorCount()=%d\n\r", p_char->getDescriptorCount());
-        
+
         for(uint8_t descIndex=0; descIndex<p_char->getDescriptorCount(); descIndex++) {
             GattAttribute *descriptor = p_char->getDescriptor(descIndex);
             uint16_t shortUUID = descriptor->getUUID().getShortUUID();
@@ -232,13 +232,13 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
             }
         }
 
-    }    
-    
+    }
+
     serviceCount++;
-    
-    //FIXME: There is no GattService pointer array in GattServer. 
+
+    //FIXME: There is no GattService pointer array in GattServer.
     //        There should be one? (Only the user is aware of GattServices!) Report to forum.
-    
+
     return BLE_ERROR_NONE;
 }
 
@@ -269,7 +269,7 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
 ble_error_t BlueNRGGattServer::read(GattAttribute::Handle_t attributeHandle, uint8_t buffer[], uint16_t *lengthP)
 {
   tBleStatus ret;
-  uint16_t charHandle = attributeHandle-BlueNRGGattServer::CHAR_VALUE_HANDLE;
+  uint16_t charHandle = attributeHandle;
 
   ret = aci_gatt_read_handle_value(charHandle, *lengthP, lengthP, buffer);
 
@@ -335,11 +335,31 @@ ble_error_t BlueNRGGattServer::write(Gap::Handle_t connectionHandle,
 
   return BLE_ERROR_NONE;
 }
-    
+
 ble_error_t BlueNRGGattServer::write(GattAttribute::Handle_t attributeHandle, const uint8_t buffer[], uint16_t len, bool localOnly)
 {
     /* avoid compiler warnings about unused variables */
     (void)localOnly;
+
+    // check that the len of the data to write are compatible with the characteristic
+    GattCharacteristic* characteristic = getCharacteristicFromHandle(attributeHandle);
+    if (!characteristic) {
+        return BLE_ERROR_INVALID_PARAM;
+    }
+
+    // assert the len in input is correct for this characteristic
+    const GattAttribute& value_attribute = characteristic->getValueAttribute();
+
+    // reject write if the lenght exceed the maximum lenght of this attribute
+    if (value_attribute.getMaxLength() < len) {
+        return BLE_ERROR_INVALID_PARAM;
+    }
+
+    // reject write if the attribute size is fixed and the lenght in input is different than the
+    // length of the attribute.
+    if (value_attribute.hasVariableLength() == false && value_attribute.getLength() != len) {
+        return BLE_ERROR_INVALID_PARAM;
+    }
 
     tBleStatus ret;
 
@@ -391,19 +411,19 @@ ble_error_t BlueNRGGattServer::write(GattAttribute::Handle_t attributeHandle, co
 ble_error_t BlueNRGGattServer::Read_Request_CB(uint16_t attributeHandle)
 {
     uint16_t gapConnectionHandle = BlueNRGGap::getInstance().getConnectionHandle();
-    
+
     GattReadCallbackParams readParams;
     readParams.handle = attributeHandle;
 
     //PRINTF("readParams.handle = %d\n\r", readParams.handle);
     HCIDataReadEvent(&readParams);
-    
+
     //EXIT:
     if(gapConnectionHandle != 0){
         //PRINTF("Calling aci_gatt_allow_read\n\r");
         aci_gatt_allow_read(gapConnectionHandle);
     }
-    
+
     return BLE_ERROR_NONE;
 }
 
@@ -444,7 +464,7 @@ GattCharacteristic* BlueNRGGattServer::getCharacteristicFromHandle(uint16_t attr
                 p_char = p_characteristics[i];
                 PRINTF("Found Characteristic Properties 0x%x (handle=%d)\n\r",p_char->getProperties(), handle);
                 break;
-            }            
+            }
         }
         else {
             handle_1 = p_characteristics[i+1]->getValueAttribute().getHandle()-BlueNRGGattServer::CHAR_VALUE_HANDLE;
@@ -464,7 +484,7 @@ GattCharacteristic* BlueNRGGattServer::getCharacteristicFromHandle(uint16_t attr
 void BlueNRGGattServer::HCIDataWrittenEvent(const GattWriteCallbackParams *params) {
     this->handleDataWrittenEvent(params);
 }
-    
+
 void BlueNRGGattServer::HCIDataReadEvent(const GattReadCallbackParams *params) {
     PRINTF("Called HCIDataReadEvent\n\r");
     this->handleDataReadEvent(params);
@@ -478,10 +498,10 @@ void BlueNRGGattServer::HCIDataSentEvent(unsigned count) {
     this->handleDataSentEvent(count);
 }
 
-    
+
 ble_error_t BlueNRGGattServer::initializeGATTDatabase(void)   {
-    // <TODO>    
-    return (ble_error_t)0;       
+    // <TODO>
+    return (ble_error_t)0;
 }
 
 /**************************************************************************/

--- a/source/BlueNRGGattServer.cpp
+++ b/source/BlueNRGGattServer.cpp
@@ -101,6 +101,8 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
         COPY_UUID_128(primary_base_uuid, base_uuid[15],base_uuid[14],primary_short_uuid[1],primary_short_uuid[0],base_uuid[11],base_uuid[10],base_uuid[9],base_uuid[8],base_uuid[7],base_uuid[6],base_uuid[5],base_uuid[4],base_uuid[3],base_uuid[2],base_uuid[1],base_uuid[0]);
     }
 
+    ret = BLE_STATUS_SUCCESS;
+
     if(type==UUID::UUID_TYPE_SHORT) {
         ret = aci_gatt_add_serv(UUID_TYPE_16,
                                 primary_short_uuid,
@@ -109,8 +111,7 @@ ble_error_t BlueNRGGattServer::addService(GattService &service)
                                 &servHandle);
         PRINTF("aci_gatt_add_serv UUID_TYPE_SHORT ret=%d\n\r", ret);
 
-    }
-    else if(type==UUID::UUID_TYPE_LONG) {
+    } else if(type==UUID::UUID_TYPE_LONG) {
         ret = aci_gatt_add_serv(UUID_TYPE_128,
                                 primary_base_uuid,
                                 PRIMARY_SERVICE,

--- a/source/BlueNRGGattServer.cpp
+++ b/source/BlueNRGGattServer.cpp
@@ -440,7 +440,7 @@ ble_error_t BlueNRGGattServer::write(GattAttribute::Handle_t attributeHandle, co
     // check that the len of the data to write are compatible with the characteristic
     GattCharacteristic* characteristic = getCharacteristicFromHandle(attributeHandle);
     if (!characteristic) {
-        printf("characteristic not found\r\n");
+        PRINTF("characteristic not found\r\n");
         return BLE_ERROR_INVALID_PARAM;
     }
 
@@ -449,14 +449,14 @@ ble_error_t BlueNRGGattServer::write(GattAttribute::Handle_t attributeHandle, co
 
     // reject write if the lenght exceed the maximum lenght of this attribute
     if (value_attribute.getMaxLength() < len) {
-        printf("invalid variable length: %u, max length is: %u\r\n", len, value_attribute.getMaxLength());
+        PRINTF("invalid variable length: %u, max length is: %u\r\n", len, value_attribute.getMaxLength());
         return BLE_ERROR_INVALID_PARAM;
     }
 
     // reject write if the attribute size is fixed and the lenght in input is different than the
     // length of the attribute.
     if (value_attribute.hasVariableLength() == false && value_attribute.getMaxLength() != len) {
-        printf("invalid fixed length: %u, len should be %u\r\n", len, value_attribute.getMaxLength());
+        PRINTF("invalid fixed length: %u, len should be %u\r\n", len, value_attribute.getMaxLength());
         return BLE_ERROR_INVALID_PARAM;
     }
 

--- a/source/platform/btle.cpp
+++ b/source/platform/btle.cpp
@@ -499,6 +499,12 @@ extern "C" {
 
                 switch(blue_evt->ecode){
 
+                // case EVT_BLUE_GATT_WRITE_PERMIT_REQ:
+                //     {
+                //         printf("write request !!!!\r\");
+                //     }
+                //     break;
+
                 case EVT_BLUE_GATT_READ_PERMIT_REQ:
                     {
                         PRINTF("EVT_BLUE_GATT_READ_PERMIT_REQ_OK\n\r");

--- a/source/platform/btle.cpp
+++ b/source/platform/btle.cpp
@@ -160,9 +160,6 @@ void btleInit(bool isSetAddress, uint8_t role)
     }
 #endif
 
-    const Gap::Address_t BLE_address_BE = {0xFD,0x66,0x05,0x13,0xBE,0xBA};
-    BlueNRGGap::getInstance().setAddress(BLEProtocol::AddressType::RANDOM_STATIC, BLE_address_BE);
-
     ret = aci_gatt_init();
     if(ret != BLE_STATUS_SUCCESS){
         PRINTF("GATT_Init failed.\n");
@@ -176,6 +173,15 @@ void btleInit(bool isSetAddress, uint8_t role)
                                    &appearance_char_handle);
     } else {
         ret = aci_gap_init_IDB04A1(role, &service_handle, &dev_name_char_handle, &appearance_char_handle);
+    }
+
+    // read the default static address and inject it into the GAP object
+    {
+        Gap::Address_t BLE_address_BE = { 0 };
+        uint8_t data_len_out;
+        aci_hal_read_config_data(CONFIG_DATA_RANDOM_ADDRESS_IDB05A1, BDADDR_SIZE, &data_len_out, BLE_address_BE);
+        // FIXME error handling of this function
+        BlueNRGGap::getInstance().setAddress(BLEProtocol::AddressType::RANDOM_STATIC, BLE_address_BE);
     }
 
     if(ret != BLE_STATUS_SUCCESS){

--- a/source/platform/btle.cpp
+++ b/source/platform/btle.cpp
@@ -17,7 +17,7 @@
 
 /**
   ******************************************************************************
-  * @file    btle.cpp 
+  * @file    btle.cpp
   * @author  STMicroelectronics
   * @brief   Implementation BlueNRG Init and helper functions.
   ******************************************************************************
@@ -31,7 +31,7 @@
   * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
   *
   * <h2><center>&copy; COPYRIGHT 2013 STMicroelectronics</center></h2>
-  */ 
+  */
 
 
 #include "btle.h"
@@ -101,7 +101,7 @@ void btleInit(bool isSetAddress, uint8_t role)
     PRINTF("btleInit>>\n\r");
     /* Avoid compiler warnings about unused variables. */
     (void)isSetAddress;
-    
+
     int ret;
     uint8_t  hwVersion;
     uint16_t fwVersion;
@@ -113,7 +113,7 @@ void btleInit(bool isSetAddress, uint8_t role)
     /* get the BlueNRG HW and FW versions */
     getBlueNRGVersion(&hwVersion, &fwVersion);
 
-    /* 
+    /*
      * Reset BlueNRG again otherwise we won't
      * be able to change its MAC address.
      * aci_hal_write_config_data() must be the first
@@ -149,10 +149,10 @@ void btleInit(bool isSetAddress, uint8_t role)
                                         CONFIG_DATA_PUBADDR_LEN,
                                         bleAddr);
     } else {
-        
+
         const Gap::Address_t BLE_address_BE = {0xFD,0x66,0x05,0x13,0xBE,0xBA};
         BlueNRGGap::getInstance().setAddress(BLEProtocol::AddressType::RANDOM_STATIC, BLE_address_BE);
-        
+
         ret = aci_hal_write_config_data(CONFIG_DATA_PUBADDR_OFFSET,
                                         CONFIG_DATA_PUBADDR_LEN,
                                         BLE_address_BE);
@@ -161,7 +161,7 @@ void btleInit(bool isSetAddress, uint8_t role)
 
     const Gap::Address_t BLE_address_BE = {0xFD,0x66,0x05,0x13,0xBE,0xBA};
     BlueNRGGap::getInstance().setAddress(BLEProtocol::AddressType::RANDOM_STATIC, BLE_address_BE);
-    
+
     ret = aci_gatt_init();
     if(ret != BLE_STATUS_SUCCESS){
         PRINTF("GATT_Init failed.\n");
@@ -176,7 +176,7 @@ void btleInit(bool isSetAddress, uint8_t role)
     } else {
         ret = aci_gap_init_IDB04A1(role, &service_handle, &dev_name_char_handle, &appearance_char_handle);
     }
-    
+
     if(ret != BLE_STATUS_SUCCESS){
         PRINTF("GAP_Init failed.\n");
     }
@@ -193,13 +193,13 @@ void btleInit(bool isSetAddress, uint8_t role)
     if (ret != BLE_STATUS_SUCCESS) {
         PRINTF("Auth Req set failed.\n");
     }
-    
+
     aci_hal_set_tx_power_level(1,4);
-    
+
     g_gap_service_handle = service_handle;
     g_appearance_char_handle = appearance_char_handle;
-    g_device_name_char_handle = dev_name_char_handle; 
-    //Device Name is set from Accumulate Adv Data Payload or through setDeviceName API  
+    g_device_name_char_handle = dev_name_char_handle;
+    //Device Name is set from Accumulate Adv Data Payload or through setDeviceName API
     /*ret = aci_gatt_update_char_value(service_handle, dev_name_char_handle, 0,
                             strlen(name), (tHalUint8 *)name);*/
 
@@ -214,7 +214,7 @@ void btleInit(bool isSetAddress, uint8_t role)
     @brief  mbedOS
 
     @param[in]  void
-    
+
     @returns
 */
 /**************************************************************************/
@@ -274,7 +274,7 @@ tBleStatus btleStartRadioScan(uint8_t scan_type,
     @brief  Not Used
 
     @param[in]  void
-    
+
     @returns
 */
 void SPI_Poll(void)
@@ -282,7 +282,7 @@ void SPI_Poll(void)
     //HAL_GPIO_EXTI_Callback_Poll(BNRG_SPI_EXTI_PIN);
     return;
 }
-   
+
 void Attribute_Modified_CB(evt_blue_aci *blue_evt)
 {
     uint16_t conn_handle;
@@ -323,7 +323,7 @@ void Attribute_Modified_CB(evt_blue_aci *blue_evt)
             currentHandle = BlueNRGGattServer::CHAR_DESC_HANDLE;
         }
         PRINTF("currentHandle %d\n\r", currentHandle);
-        if((p_char->getProperties() & 
+        if((p_char->getProperties() &
             (GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_INDICATE)) &&
             currentHandle == BlueNRGGattServer::CHAR_DESC_HANDLE) {
 
@@ -332,21 +332,21 @@ void Attribute_Modified_CB(evt_blue_aci *blue_evt)
             PRINTF("*****NOTIFICATION CASE\n\r");
             //Now Check if data written in Enable or Disable
             if((uint16_t)att_data[0]==1) {
-                //PRINTF("Notify ENABLED\n\r"); 
+                //PRINTF("Notify ENABLED\n\r");
                 BlueNRGGattServer::getInstance().HCIEvent(GattServerEvents::GATT_EVENT_UPDATES_ENABLED, charDescHandle);
             } else {
-                //PRINTF("Notify DISABLED\n\r"); 
+                //PRINTF("Notify DISABLED\n\r");
                 BlueNRGGattServer::getInstance().HCIEvent(GattServerEvents::GATT_EVENT_UPDATES_DISABLED, charDescHandle);
             }
         }
-                    
+
         //Check if attr handle property is WRITEABLE, in the case generate GATT_EVENT_DATA_WRITTEN Event
         if((p_char->getProperties() &
             (GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE_WITHOUT_RESPONSE | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE)) &&
             currentHandle == BlueNRGGattServer::CHAR_VALUE_HANDLE) {
-                    
+
             PRINTF("*****WRITE CASE\n\r");
-                   
+
             GattWriteCallbackParams writeParams;
             writeParams.connHandle = conn_handle;
             writeParams.handle = p_char->getValueAttribute().getHandle();
@@ -365,7 +365,7 @@ void Attribute_Modified_CB(evt_blue_aci *blue_evt)
                                                        data_length,
                                                        false);
             }
-        } 
+        }
     }
 
 }
@@ -380,39 +380,39 @@ extern "C" {
 
     @param[in]  pckt
                 Event Packet sent by the stack to be decoded
-    
+
     @returns
     */
     /**************************************************************************/
     extern void HCI_Event_CB(void *pckt) {
         hci_uart_pckt *hci_pckt = (hci_uart_pckt*)pckt;
         hci_event_pckt *event_pckt = (hci_event_pckt*)hci_pckt->data;
-        
+
         if(hci_pckt->type != HCI_EVENT_PKT)
           return;
 
         switch(event_pckt->evt){
-            
+
         case EVT_DISCONN_COMPLETE:
             {
                 PRINTF("EVT_DISCONN_COMPLETE\n");
-                
+
                 evt_disconn_complete *evt = (evt_disconn_complete*)event_pckt->data;
-                
+
                 BlueNRGGap::getInstance().processDisconnectionEvent(evt->handle, (Gap::DisconnectionReason_t)evt->reason);
             }
             break;
-            
+
         case EVT_LE_META_EVENT:
             {
                 PRINTF("EVT_LE_META_EVENT\n");
-                
+
                 evt_le_meta_event *evt = (evt_le_meta_event *)event_pckt->data;
-                
+
                 switch(evt->subevent){
 
                 case EVT_LE_CONN_COMPLETE:
-                    {                            
+                    {
                         PRINTF("EVT_LE_CONN_COMPLETE\n");
                         Gap::Address_t ownAddr;
                         Gap::AddressType_t ownAddrType;
@@ -420,12 +420,19 @@ extern "C" {
 
                         Gap::AddressType_t peerAddrType = BLEProtocol::AddressType::RANDOM_STATIC;
                         Gap::Role_t role;
-                        
+
                         evt_le_connection_complete *cc = (evt_le_connection_complete *)evt->data;
-                        
+
                         BlueNRGGap::getInstance().setConnectionHandle(cc->handle);
-                        BlueNRGGap::ConnectionParams_t connectionParams;
-                        BlueNRGGap::getInstance().getPreferredConnectionParams(&connectionParams);
+                        BlueNRGGap::ConnectionParams_t connectionParams = {
+                            /* minConnectionInterval = */ cc->interval,
+                            /*  maxConnectionInterval = */ cc->interval,
+                            /* slaveLatency = */ cc->latency,
+                            /* connectionSupervisionTimeout = */ cc->supervision_timeout
+                        };
+
+                        BlueNRGGap::getInstance().setConnectionInterval(cc->interval);
+
                         switch (cc->peer_bdaddr_type) {
                             case PUBLIC_ADDR:
                                 peerAddrType = BLEProtocol::AddressType::PUBLIC;
@@ -439,7 +446,7 @@ extern "C" {
                             case NON_RESOLVABLE_PRIVATE_ADDR:
                                 peerAddrType = BLEProtocol::AddressType::RANDOM_PRIVATE_NON_RESOLVABLE;
                                 break;
-                        }                                             
+                        }
                         //PRINTF("EVT_LE_CONN_COMPLETE LL role=%d\n", cc->role);
                         switch (cc->role) {
 			case 0: //master
@@ -462,17 +469,17 @@ extern "C" {
                                                                          &connectionParams);
                     }
                     break;
-          
+
         case EVT_LE_ADVERTISING_REPORT:
           PRINTF("EVT_LE_ADVERTISING_REPORT\n\r");
           /* FIXME: comment this otherwise it will be obscure and error prone if BlueNRG FW will be updated */
           // This event is generated only by X-NUCLEO-IDB05A1 version but not by X-NUCLEO-IDB04A1 (which generates DEVICE_FOUND EVT)
           // Formally the structure related to both events are identical except that for the ADV REPORT
           // there is one more field (number of reports) which is not forwarded to upper layer.
-          // Thus we need to move one byte over (((uint8_t*)evt->data)+1) before persing the ADV REPORT. 
+          // Thus we need to move one byte over (((uint8_t*)evt->data)+1) before persing the ADV REPORT.
           le_advertising_info *pr = (le_advertising_info*) (((uint8_t*)evt->data)+1);
           PRINTF("EVT_LE_ADVERTISING_REPORT evt_type=%d\n\r", pr->evt_type);
-          
+
           BlueNRGGap::getInstance().Discovery_CB(BlueNRGGap::DEVICE_FOUND,
                                                  pr->evt_type,
                                                  pr->bdaddr_type,
@@ -484,14 +491,14 @@ extern "C" {
                 }
             }
             break;
-            
+
         case EVT_VENDOR:
-            {                
+            {
                 evt_blue_aci *blue_evt = (evt_blue_aci*)event_pckt->data;
                 //PRINTF("EVT_VENDOR %d\n", blue_evt->ecode);
-                
+
                 switch(blue_evt->ecode){
-                           
+
                 case EVT_BLUE_GATT_READ_PERMIT_REQ:
                     {
                         PRINTF("EVT_BLUE_GATT_READ_PERMIT_REQ_OK\n\r");
@@ -500,16 +507,16 @@ extern "C" {
                         BlueNRGGattServer::getInstance().Read_Request_CB(pr->attr_handle);
                     }
                     break;
-                    
-                case EVT_BLUE_GATT_ATTRIBUTE_MODIFIED:         
+
+                case EVT_BLUE_GATT_ATTRIBUTE_MODIFIED:
                     {
                         PRINTF("EVT_BLUE_GATT_ATTRIBUTE_MODIFIED\n\r");
                         /* this callback is invoked when a GATT attribute is modified
                             extract callback data and pass to suitable handler function */
                         Attribute_Modified_CB(blue_evt);
                     }
-                    break;  
-                    
+                    break;
+
                     //Any cases for Data Sent Notifications?
                 case EVT_BLUE_GATT_NOTIFICATION:
                     //This is only relevant for Client Side Event
@@ -518,8 +525,8 @@ extern "C" {
                 case EVT_BLUE_GATT_INDICATION:
                     //This is only relevant for Client Side Event
                     PRINTF("EVT_BLUE_GATT_INDICATION");
-                    break;   
-                    
+                    break;
+
         case EVT_BLUE_ATT_READ_BY_GROUP_TYPE_RESP:
           {
             PRINTF("EVT_BLUE_ATT_READ_BY_GROUP_TYPE_RESP\n\r");
@@ -604,12 +611,12 @@ extern "C" {
             BlueNRGGattClient::getInstance().gattProcedureCompleteCB(evt->conn_handle, evt->error_code);
           }
           break;
-          
+
         case EVT_BLUE_GAP_DEVICE_FOUND:
           {
             evt_gap_device_found *pr = (evt_gap_device_found*)blue_evt->data;
             PRINTF("EVT_BLUE_GAP_DEVICE_FOUND evt_type=%d\n\r", pr->evt_type);
-            
+
             BlueNRGGap::getInstance().Discovery_CB(BlueNRGGap::DEVICE_FOUND,
                                                    pr->evt_type,
                                                    pr->bdaddr_type,
@@ -619,24 +626,24 @@ extern "C" {
                                                    &pr->data_RSSI[pr->data_length]);
           }
           break;
-          
+
         case EVT_BLUE_GAP_PROCEDURE_COMPLETE:
           {
             evt_gap_procedure_complete *pr = (evt_gap_procedure_complete*)blue_evt->data;
             //PRINTF("EVT_BLUE_GAP_PROCEDURE_COMPLETE (code=0x%02X)\n\r", pr->procedure_code);
-            
+
             switch(pr->procedure_code) {
             case GAP_OBSERVATION_PROC_IDB05A1:
-              
+
               BlueNRGGap::getInstance().Discovery_CB(BlueNRGGap::DISCOVERY_COMPLETE, 0, 0, NULL, NULL, NULL, NULL);
               break;
             }
           }
-                    break;                                     
+                    break;
                 }
             }
             break;
-        }    
+        }
         return ;
     }
 

--- a/source/platform/btle.cpp
+++ b/source/platform/btle.cpp
@@ -338,6 +338,7 @@ void Attribute_Modified_CB(evt_blue_aci *blue_evt)
                 //PRINTF("Notify DISABLED\n\r");
                 BlueNRGGattServer::getInstance().HCIEvent(GattServerEvents::GATT_EVENT_UPDATES_DISABLED, charDescHandle);
             }
+            return;
         }
 
         //Check if attr handle property is WRITEABLE, in the case generate GATT_EVENT_DATA_WRITTEN Event
@@ -355,16 +356,28 @@ void Attribute_Modified_CB(evt_blue_aci *blue_evt)
             writeParams.data = att_data;
             writeParams.offset = offset;
 
-            BlueNRGGattServer::getInstance().HCIDataWrittenEvent(&writeParams);
-
             //BlueNRGGattServer::getInstance().handleEvent(GattServerEvents::GATT_EVENT_DATA_WRITTEN, attr_handle);
             //Write the actual Data to the Attr Handle? (uint8_1[])att_data contains the data
             if ((p_char->getValueAttribute().getValuePtr() != NULL) && (p_char->getValueAttribute().getLength() > 0)) {
                 BlueNRGGattServer::getInstance().write(p_char->getValueAttribute().getHandle(),
-                                                       (uint8_t*)att_data,
-                                                       data_length,
-                                                       false);
+                (uint8_t*)att_data,
+                data_length,
+                false);
+
+            BlueNRGGattServer::getInstance().HCIDataWrittenEvent(&writeParams);
             }
+        } else {
+            PRINTF("*****WRITE DESCRIPTOR CASE\n\r");
+
+            GattWriteCallbackParams writeParams;
+            writeParams.connHandle = conn_handle;
+            writeParams.handle = attr_handle;
+            writeParams.writeOp = GattWriteCallbackParams::OP_WRITE_REQ;//Where to find this property in BLUENRG?
+            writeParams.len = data_length;
+            writeParams.data = att_data;
+            writeParams.offset = offset;
+
+            BlueNRGGattServer::getInstance().HCIDataWrittenEvent(&writeParams);
         }
     }
 

--- a/source/platform/btle.cpp
+++ b/source/platform/btle.cpp
@@ -81,6 +81,7 @@ void HCI_Input(tHciDataPacket * hciReadPacket);
 uint16_t g_gap_service_handle = 0;
 uint16_t g_appearance_char_handle = 0;
 uint16_t g_device_name_char_handle = 0;
+uint16_t g_preferred_connection_parameters_char_handle = 0;
 
 /* Private variables ---------------------------------------------------------*/
 volatile uint8_t set_connectable = 1;
@@ -202,6 +203,15 @@ void btleInit(bool isSetAddress, uint8_t role)
     //Device Name is set from Accumulate Adv Data Payload or through setDeviceName API
     /*ret = aci_gatt_update_char_value(service_handle, dev_name_char_handle, 0,
                             strlen(name), (tHalUint8 *)name);*/
+
+    // update the peripheral preferred conenction parameters handle
+    // if the device is configured as a peripheral
+    // This value is hardcoded at the moment.
+    if ((role & GAP_PERIPHERAL_ROLE_IDB05A1) || (role & GAP_PERIPHERAL_ROLE_IDB04A1) ||
+        (bnrg_expansion_board == IDB05A1 /* role is ignored in this configuration ... */)) {
+        g_preferred_connection_parameters_char_handle = 10;
+    }
+
 
 #ifdef AST_FOR_MBED_OS
     minar::Scheduler::postCallback(btle_handler);

--- a/source/platform/btle.cpp
+++ b/source/platform/btle.cpp
@@ -545,7 +545,7 @@ extern "C" {
                         uint8_t write_status = err_code == 0 ? 0 : 1;
 
                         // reply to the shield
-                        tBleStatus err = aci_gatt_write_response(
+                        aci_gatt_write_response(
                             write_req->conn_handle,
                             write_req->attr_handle,
                             write_status,

--- a/source/platform/btle.cpp
+++ b/source/platform/btle.cpp
@@ -426,7 +426,7 @@ extern "C" {
                         BlueNRGGap::getInstance().setConnectionHandle(cc->handle);
                         BlueNRGGap::ConnectionParams_t connectionParams = {
                             /* minConnectionInterval = */ cc->interval,
-                            /*  maxConnectionInterval = */ cc->interval,
+                            /* maxConnectionInterval = */ cc->interval,
                             /* slaveLatency = */ cc->latency,
                             /* connectionSupervisionTimeout = */ cc->supervision_timeout
                         };
@@ -459,7 +459,9 @@ extern "C" {
                                 role = Gap::PERIPHERAL;
 				break;
                         }
-                        //PRINTF("EVT_LE_CONN_COMPLETE GAP role=%d\n", role);
+
+                        BlueNRGGap::getInstance().setGapRole(role);
+
                         BlueNRGGap::getInstance().processConnectionEvent(cc->handle,
                                                                          role,
                                                                          peerAddrType,
@@ -635,6 +637,36 @@ extern "C" {
             evt_gatt_procedure_complete *evt = (evt_gatt_procedure_complete*)blue_evt->data;
             PRINTF("EVT_BLUE_GATT_PROCEDURE_COMPLETE error_code=%d\n\r", evt->error_code);
             BlueNRGGattClient::getInstance().gattProcedureCompleteCB(evt->conn_handle, evt->error_code);
+          }
+          break;
+
+        case EVT_BLUE_L2CAP_CONN_UPD_REQ:
+          {
+            PRINTF("EVT_BLUE_L2CAP_CONN_UPD_REQ\r\n");
+            evt_l2cap_conn_upd_req *evt = (evt_l2cap_conn_upd_req*)blue_evt->data;
+            if(bnrg_expansion_board == IDB05A1) {
+              // we assume the application accepts the request from the slave
+              aci_l2cap_connection_parameter_update_response_IDB05A1(evt->conn_handle,
+                                                                     evt->interval_min,
+                                                                     evt->interval_max,
+                                                                     evt->slave_latency,
+                                                                     evt->timeout_mult,
+                                                                     CONN_L1, CONN_L2,
+                                                                     evt->identifier,
+                                                                     0x0000);
+            }
+          }
+          break;
+
+        case EVT_BLUE_L2CAP_CONN_UPD_RESP:
+          {
+            PRINTF("EVT_BLUE_L2CAP_CONN_UPD_RESP\r\n");
+          }
+          break;
+
+        case EVT_LE_CONN_UPDATE_COMPLETE:
+          {
+            PRINTF("EVT_LE_CONN_UPDATE_COMPLETE\r\n");
           }
           break;
 

--- a/x-nucleo-idb0xa1/BlueNRGDiscoveredCharacteristic.h
+++ b/x-nucleo-idb0xa1/BlueNRGDiscoveredCharacteristic.h
@@ -30,7 +30,7 @@ public:
              GattAttribute::Handle_t  declHandleIn,
              GattAttribute::Handle_t  valueHandleIn,
              GattAttribute::Handle_t  lastHandleIn);
-  
+
   void setup(BlueNRGGattClient         *gattcIn,
              Gap::Handle_t            connectionHandleIn,
              UUID   uuidIn,
@@ -38,6 +38,9 @@ public:
              GattAttribute::Handle_t  declHandleIn,
              GattAttribute::Handle_t  valueHandleIn,
              GattAttribute::Handle_t  lastHandleIn);
+
+
+  void setLastHandle(GattAttribute::Handle_t  lastHandleIn);
 };
 
 #endif /* __BLUENRG_DISCOVERED_CHARACTERISTIC_H__ */

--- a/x-nucleo-idb0xa1/BlueNRGGap.h
+++ b/x-nucleo-idb0xa1/BlueNRGGap.h
@@ -153,6 +153,8 @@ public:
 
     virtual ble_error_t startRadioScan(const GapScanningParams &scanningParams);
 
+    void setConnectionInterval(uint16_t interval);
+
 private:
     uint16_t m_connectionHandle;
     AddressType_t addr_type;

--- a/x-nucleo-idb0xa1/BlueNRGGap.h
+++ b/x-nucleo-idb0xa1/BlueNRGGap.h
@@ -150,9 +150,11 @@ public:
     virtual ble_error_t startRadioScan(const GapScanningParams &scanningParams);
 
     void setConnectionInterval(uint16_t interval);
+    void setGapRole(Role_t role);
 
 private:
     uint16_t m_connectionHandle;
+    Role_t gapRole;
     AddressType_t addr_type;
     Address_t _peerAddr;
     AddressType_t _peerAddrType;

--- a/x-nucleo-idb0xa1/BlueNRGGap.h
+++ b/x-nucleo-idb0xa1/BlueNRGGap.h
@@ -66,10 +66,6 @@
 #define MAX_INT_CONN   0x0C80 //=>4000msec
 #define DEF_INT_CONN   0x0140 //=>400msec (default value for connection interval)
 
-#define LOCAL_NAME_MAX_SIZE 9 //8 + 1(AD_DATA_TYPE)
-#define UUID_BUFFER_SIZE 17 //Either 8*2(16-bit UUIDs) or 4*4(32-bit UUIDs) or 1*16(128-bit UUIDs) +1(AD_DATA_TYPE)
-#define ADV_DATA_MAX_SIZE 31
-
 /**************************************************************************/
 /*!
     \brief
@@ -166,22 +162,8 @@ private:
     bool isSetAddress;
     uint8_t deviceAppearance[2];
 
-    uint8_t local_name_length;
-    uint8_t local_name[ADV_DATA_MAX_SIZE];//LOCAL_NAME_MAX_SIZE];
-
-    uint8_t servUuidlength;
-    uint8_t servUuidData[UUID_BUFFER_SIZE];
-
-    uint8_t AdvLen;
-    uint8_t AdvData[ADV_DATA_MAX_SIZE];
-
-    uint8_t txPowLevSet;
-
     Timeout advTimeout;
     bool AdvToFlag;
-
-    const uint8_t *scan_response_payload;
-    uint8_t scan_rsp_length;
 
     static uint16_t SCAN_DURATION_UNITS_TO_MSEC(uint16_t duration) {
         return (duration * 625) / 1000;
@@ -204,7 +186,7 @@ private:
 
     ble_error_t updateAdvertisingData(void);
 
-    BlueNRGGap(): txPowLevSet(0) {
+    BlueNRGGap() {
         m_connectionHandle = BLE_CONN_HANDLE_INVALID;
         addr_type = BLEProtocol::AddressType::RANDOM_STATIC;
 
@@ -220,6 +202,7 @@ private:
     void operator=(BlueNRGGap const &);
 
     GapAdvertisingData _advData;
+    GapAdvertisingData _scanResponse;
 };
 
 #endif // ifndef __BLUENRG_GAP_H__

--- a/x-nucleo-idb0xa1/BlueNRGGap.h
+++ b/x-nucleo-idb0xa1/BlueNRGGap.h
@@ -16,7 +16,7 @@
 
 /**
   ******************************************************************************
-  * @file    BlueNRGGap.h 
+  * @file    BlueNRGGap.h
   * @author  STMicroelectronics
   * @brief   Header file for BlueNRG BLE_API Gap Class
   ******************************************************************************
@@ -30,8 +30,8 @@
   * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
   *
   * <h2><center>&copy; COPYRIGHT 2013 STMicroelectronics</center></h2>
-  */ 
-  
+  */
+
 #ifndef __BLUENRG_GAP_H__
 #define __BLUENRG_GAP_H__
 
@@ -88,7 +88,7 @@ public:
         DEVICE_FOUND,
         DISCOVERY_COMPLETE
     };
-    
+
     /* Functions that must be implemented from Gap */
     virtual ble_error_t setAddress(addr_type_t type,   const Address_t address);
     virtual ble_error_t getAddress(addr_type_t *typeP, Address_t address);
@@ -136,9 +136,9 @@ public:
 
     void     setConnectionHandle(uint16_t con_handle);
     uint16_t getConnectionHandle(void);
-    
+
     bool getIsSetAddress();
-    
+
     Timeout getAdvTimeout(void) const {
         return advTimeout;
     }
@@ -146,7 +146,7 @@ public:
         return AdvToFlag;
     }
     void setAdvToFlag(void);
-    
+
     void Process(void);
 
     GapScanningParams* getScanningParams(void);
@@ -174,7 +174,7 @@ private:
     uint8_t AdvData[ADV_DATA_MAX_SIZE];
 
     uint8_t txPowLevSet;
-    
+
     Timeout advTimeout;
     bool AdvToFlag;
 
@@ -216,6 +216,8 @@ private:
 
     BlueNRGGap(BlueNRGGap const &);
     void operator=(BlueNRGGap const &);
+
+    GapAdvertisingData _advData;
 };
 
 #endif // ifndef __BLUENRG_GAP_H__

--- a/x-nucleo-idb0xa1/BlueNRGGattServer.h
+++ b/x-nucleo-idb0xa1/BlueNRGGattServer.h
@@ -15,7 +15,7 @@
 */
 /**
   ******************************************************************************
-  * @file    BlueNRGGattServer.cpp 
+  * @file    BlueNRGGattServer.cpp
   * @author  STMicroelectronics
   * @brief   Header file for BLE_API GattServer Class
   ******************************************************************************
@@ -30,7 +30,7 @@
   *
   * <h2><center>&copy; COPYRIGHT 2013 STMicroelectronics</center></h2>
   */
- 
+
 #ifndef __BLUENRG_GATT_SERVER_H__
 #define __BLUENRG_GATT_SERVER_H__
 
@@ -53,13 +53,13 @@ public:
         static BlueNRGGattServer m_instance;
         return m_instance;
     }
-    
+
     enum HandleEnum_t {
         CHAR_HANDLE = 0,
         CHAR_VALUE_HANDLE,
         CHAR_DESC_HANDLE
     };
-    
+
     /* Functions that must be implemented from GattServer */
     virtual ble_error_t addService(GattService &);
     virtual ble_error_t read(GattAttribute::Handle_t attributeHandle, uint8_t buffer[], uint16_t *lengthP);
@@ -67,13 +67,13 @@ public:
     virtual ble_error_t write(GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false);
     virtual ble_error_t write(Gap::Handle_t connectionHandle, GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false);
     virtual ble_error_t initializeGATTDatabase(void);
-    
+
     virtual bool isOnDataReadAvailable() const {
         return true;
     }
 
     virtual ble_error_t reset(void);
-    
+
     /* BlueNRG Functions */
     void eventCallback(void);
     //void hwCallback(void *pckt);
@@ -83,8 +83,13 @@ public:
     void HCIDataReadEvent(const GattReadCallbackParams *params);
     void HCIEvent(GattServerEvents::gattEvent_e type, uint16_t charHandle);
     void HCIDataSentEvent(unsigned count);
-    
+
 private:
+
+    // compute the number of attribute record needed by a service
+    static uint16_t computeAttributesRecord(GattService& service);
+
+
     static const int MAX_SERVICE_COUNT = 10;
     uint8_t serviceCount;
     uint8_t characteristicCount;
@@ -101,12 +106,12 @@ private:
 
     BlueNRGGattServer(BlueNRGGattServer const &);
     void operator=(BlueNRGGattServer const &);
-    
-    static const int CHAR_DESC_TYPE_16_BIT=0x01; 
-    static const int CHAR_DESC_TYPE_128_BIT=0x02;    
+
+    static const int CHAR_DESC_TYPE_16_BIT=0x01;
+    static const int CHAR_DESC_TYPE_128_BIT=0x02;
     static const int CHAR_DESC_SECURITY_PERMISSION=0x00;
-    static const int CHAR_DESC_ACCESS_PERMISSION=0x03;  
-    static const int CHAR_ATTRIBUTE_LEN_IS_FIXED=0x00;        
+    static const int CHAR_DESC_ACCESS_PERMISSION=0x03;
+    static const int CHAR_ATTRIBUTE_LEN_IS_FIXED=0x00;
 };
 
 #endif

--- a/x-nucleo-idb0xa1/BlueNRGGattServer.h
+++ b/x-nucleo-idb0xa1/BlueNRGGattServer.h
@@ -78,6 +78,10 @@ public:
     void eventCallback(void);
     //void hwCallback(void *pckt);
     ble_error_t Read_Request_CB(uint16_t attributeHandle);
+    uint8_t Write_Request_CB(
+        uint16_t connection_handle, uint16_t attr_handle,
+        uint8_t data_length, const uint8_t* data
+    );
     GattCharacteristic* getCharacteristicFromHandle(uint16_t charHandle);
     void HCIDataWrittenEvent(const GattWriteCallbackParams *params);
     void HCIDataReadEvent(const GattReadCallbackParams *params);

--- a/x-nucleo-idb0xa1/bluenrg-hci/debug.h
+++ b/x-nucleo-idb0xa1/bluenrg-hci/debug.h
@@ -1,6 +1,6 @@
 /**
   ******************************************************************************
-  * @file    debug.h 
+  * @file    debug.h
   * @author  CL
   * @version V1.0.0
   * @date    04-July-2014
@@ -41,7 +41,7 @@
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 /* Includes ------------------------------------------------------------------*/
 #include <string.h>
@@ -56,7 +56,7 @@
 #endif
 
 /* Print the data travelling over the SPI in the .csv format for the GUI*/
-//#define PRINT_CSV_FORMAT 
+//#define PRINT_CSV_FORMAT
 #ifdef PRINT_CSV_FORMAT
 #include <stdio.h>
 #define PRINT_CSV(...) printf(__VA_ARGS__)

--- a/x-nucleo-idb0xa1/platform/btle.h
+++ b/x-nucleo-idb0xa1/platform/btle.h
@@ -39,7 +39,7 @@ extern uint16_t g_appearance_char_handle;
 extern uint16_t g_device_name_char_handle;
 extern uint16_t g_preferred_connection_parameters_char_handle;
 
-void btleInit(bool isSetAddress, uint8_t role);
+void btleInit(void);
 void SPI_Poll(void);
 void User_Process(void);
 void setConnectable(void);

--- a/x-nucleo-idb0xa1/platform/btle.h
+++ b/x-nucleo-idb0xa1/platform/btle.h
@@ -25,19 +25,20 @@ extern "C" {
 
 #include <stdio.h>
 #include <string.h>
-	
+
 #include "hci.h"
-#include "bluenrg_aci.h"	
-#include "hci_const.h"	
+#include "bluenrg_aci.h"
+#include "hci_const.h"
 #include "bluenrg_hal_aci.h"
-#include "stm32_bluenrg_ble.h"	
+#include "stm32_bluenrg_ble.h"
 #include "bluenrg_gap.h"
 #include "bluenrg_gatt_server.h"
 
 extern uint16_t g_gap_service_handle;
 extern uint16_t g_appearance_char_handle;
 extern uint16_t g_device_name_char_handle;
-	
+extern uint16_t g_preferred_connection_parameters_char_handle;
+
 void btleInit(bool isSetAddress, uint8_t role);
 void SPI_Poll(void);
 void User_Process(void);


### PR DESCRIPTION
Final tests results are in line with what we expected: 

```
+-------------------------------------+---------+--------------------------------+-------------+----------+
| Testcase                            | Verdict |          Fail Reason           | Skip Reason | duration |
+-------------------------------------+---------+--------------------------------+-------------+----------+
| Ble_test_05                         |   pass  |                                |             |   6.73   |
| Ble_test_04                         |   pass  |                                |             |  4.574   |
| Ble_test_07                         |   pass  |                                |             |  5.551   |
| Ble_test_06                         |   pass  |                                |             |  3.375   |
| Ble_test_01                         |   pass  |                                |             |  3.088   |
| Ble_test_03                         |   pass  |                                |             |  4.927   |
| Ble_test_02                         |   pass  |                                |             |  3.224   |
| GapAdvertisingPayload_test_01       |   pass  |                                |             |   58.4   |
| GapAdvertisingInterval_test_01      |   pass  |                                |             |  61.155  |
| GapAdvertisingInterval_test_02      |   pass  |                                |             |  62.504  |
| GapAdvertisingInterval_test_03      |   pass  |                                |             |  57.764  |
| GapIntervalTimeout_test_01          |   pass  |                                |             | 128.715  |
| GapState_test_04                    |   pass  |                                |             |  15.616  |
| GapState_test_05                    |   pass  |                                |             |  13.129  |
| GapState_test_06                    |   pass  |                                |             |  16.069  |
| GapState_test_07                    |   pass  |                                |             |  16.364  |
| GapState_test_01                    |   pass  |                                |             |  12.794  |
| GapState_test_02                    |   pass  |                                |             |  12.908  |
| GapState_test_03                    |   pass  |                                |             |  12.536  |
| GapAdvertisingConstants_test_05     |   pass  |                                |             |  3.714   |
| GapAdvertisingConstants_test_06     |   pass  |                                |             |  7.245   |
| GapAdvertisingConstants_test_03     |   pass  |                                |             |  3.668   |
| GapAdvertisingConstants_test_02     |   pass  |                                |             |  7.216   |
| GapAdvertisingConstants_test_01     |   pass  |                                |             |  3.485   |
| GapAdvertisingConstants_test_04     |   pass  |                                |             |  8.859   |
| GapAddress_test_01                  |   pass  |                                |             |  9.129   |
| GapAddress_test_03                  |   pass  |                                |             |  19.179  |
| GapAddress_test_02                  |   pass  |                                |             |  9.684   |
| GapAddress_test_05                  |   fail  | dut1 cmd: 'gap setAddress ADDR |             |  8.492   |
| GapAddress_test_04                  |   fail  | dut1 cmd: 'gap setAddress ADDR |             |  8.232   |
| GapAddress_test_06                  |   fail  | dut1 cmd: 'gap setAddress ADDR |             |  8.334   |
| GapAppearance_test_03               |   pass  |                                |             |   6.21   |
| GapAppearance_test_02               |   pass  |                                |             |  11.453  |
| GapAppearance_test_01               |   pass  |                                |             |  36.032  |
| GapDeviceName_test_03               |   pass  |                                |             |  7.355   |
| GapDeviceName_test_05               |   pass  |                                |             |  9.195   |
| GapDeviceName_test_01               |   pass  |                                |             |  3.675   |
| GapDeviceName_test_02               |   pass  |                                |             |  10.338  |
| GapDeviceName_test_04               |   pass  |                                |             |  5.822   |
| GapConnectionParameters_test_06     |   pass  |                                |             |  4.308   |
| GapConnectionParameters_test_07     |   pass  |                                |             |  9.368   |
| GapConnectionParameters_test_04     |   pass  |                                |             |  12.378  |
| GapConnectionParameters_test_05     |   pass  |                                |             |  12.556  |
| GapConnectionParameters_test_02     |   pass  |                                |             |  7.796   |
| GapConnectionParameters_test_03     |   pass  |                                |             |  4.189   |
| GapConnectionParameters_test_01     |   pass  |                                |             |  3.614   |
| GapStartStopAdvertising_test_01     |   pass  |                                |             |  20.492  |
| GapStartStopAdvertising_test_02     |   pass  |                                |             |  13.492  |
| GapStartStopScan_test_01            |   pass  |                                |             |  11.799  |
| GapStartStopScan_test_02            |   pass  |                                |             |  11.673  |
| GapTxPower_test_04                  |   pass  |                                |             |  63.091  |
| GapTxPower_test_05                  |   pass  |                                |             |  17.514  |
| GapTxPower_test_02                  |   pass  |                                |             |  10.22   |
| GapTxPower_test_03                  |   pass  |                                |             |  9.886   |
| GapTxPower_test_01                  |   pass  |                                |             |  6.381   |
| WhiteListAdvPolicy_test_04          |   fail  | dut1 cmd: 'gap setWhitelist AD |             |  10.664  |
| WhiteListAdvPolicy_test_01          |   fail  | dut1 cmd: 'gap setWhitelist ', |             |  10.076  |
| WhiteListAdvPolicy_test_03          |   fail  | dut1 cmd: 'gap setWhitelist AD |             |  10.487  |
| WhiteListAdvPolicy_test_02          |   fail  | dut1 cmd: 'gap setWhitelist AD |             |  10.742  |
| WhiteListAdvPolicy_test_05          |   fail  | dut1 cmd: 'gap setWhitelist AD |             |  10.631  |
| WhiteListAdvPolicy_test_09          |   fail  | dut1 cmd: 'gap setWhitelist AD |             |  10.524  |
| WhiteListAdvPolicy_test_08          |   fail  | dut1 cmd: 'gap setWhitelist AD |             |   10.6   |
| WhiteListAdvPolicy_test_06          |   fail  | dut1 cmd: 'gap setWhitelist AD |             |  10.695  |
| WhiteListAdvPolicy_test_07          |   fail  | dut1 cmd: 'gap setWhitelist AD |             |  10.636  |
| WhiteListScanPolicy_test_02         |   fail  | dut2 cmd: 'gap setWhitelist AD |             |  9.024   |
| WhiteListScanPolicy_test_04         |   fail  | dut2 cmd: 'gap setWhitelist ', |             |  8.653   |
| WhiteListScanPolicy_test_05         |   fail  | dut2 cmd: 'gap setWhitelist AD |             |  9.034   |
| WhiteListScanPolicy_test_06         |   fail  | dut2 cmd: 'gap setWhitelist AD |             |  8.984   |
| WhiteListScanPolicy_test_01         |   fail  | dut2 cmd: 'gap setWhitelist ', |             |  8.667   |
| WhiteListScanPolicy_test_03         |   fail  | dut2 cmd: 'gap setWhitelist AD |             |  8.925   |
| GenericAccessService_test_01        |   pass  |                                |             |  14.596  |
| GenericAccessService_test_02        |   pass  |                                |             |   16.5   |
| GenericAccessService_test_05        |   pass  |                                |             |  28.807  |
| GenericAccessService_test_03        |   pass  |                                |             |  30.726  |
| GenericAccessService_test_04        |   pass  |                                |             |  38.284  |
| CharacteristicInstantiation_test_01 |   pass  |                                |             | 1737.109 |
| CharacteristicInstantiation_test_02 |   pass  |                                |             | 1778.856 |
| CharacteristicReadWrite_test_06     |   pass  |                                |             |  13.576  |
| CharacteristicReadWrite_test_07     |   pass  |                                |             |  12.754  |
| CharacteristicReadWrite_test_04     |   pass  |                                |             |  17.321  |
| CharacteristicReadWrite_test_05     |   pass  |                                |             |  14.705  |
| CharacteristicReadWrite_test_02     |   pass  |                                |             |  17.218  |
| CharacteristicReadWrite_test_03     |   pass  |                                |             |  13.747  |
| CharacteristicReadWrite_test_01     |   pass  |                                |             |  13.264  |
| CharacteristicReadWrite_test_08     |   pass  |                                |             |  26.63   |
| CharacteristicReadWrite_test_09     |   pass  |                                |             |   13.0   |
| CharacteristicReadWrite_test_15     |   pass  |                                |             |  14.854  |
| CharacteristicReadWrite_test_14     |   pass  |                                |             |  6.127   |
| CharacteristicReadWrite_test_16     |   pass  |                                |             |  14.665  |
| CharacteristicReadWrite_test_11     |   pass  |                                |             |  12.367  |
| CharacteristicReadWrite_test_10     |   pass  |                                |             |  21.304  |
| CharacteristicReadWrite_test_13     |   pass  |                                |             |  6.062   |
| CharacteristicReadWrite_test_12     |   pass  |                                |             |  46.143  |
| DescriptorInstantiation_test_14     |   pass  |                                |             |  32.724  |
| DescriptorInstantiation_test_12     |   pass  |                                |             |  43.162  |
| DescriptorInstantiation_test_11     |   pass  |                                |             |  37.187  |
| DescriptorInstantiation_test_10     |   pass  |                                |             |  34.507  |
| DescriptorInstantiation_test_19     |   pass  |                                |             |  33.338  |
| DescriptorInstantiation_test_18     |   pass  |                                |             |  31.658  |
| DescriptorInstantiation_test_17     |   pass  |                                |             |  43.49   |
| DescriptorInstantiation_test_21     |   pass  |                                |             |  37.653  |
| DescriptorInstantiation_test_16     |   pass  |                                |             |  37.218  |
| DescriptorInstantiation_test_13     |   pass  |                                |             |  31.168  |
| DescriptorInstantiation_test_15     |   pass  |                                |             |  34.524  |
| DescriptorInstantiation_test_20     |   pass  |                                |             |  34.721  |
| DescriptorInstantiation_test_09     |   pass  |                                |             |  32.884  |
| DescriptorInstantiation_test_08     |   pass  |                                |             |  31.149  |
| DescriptorInstantiation_test_04     |   pass  |                                |             |  27.337  |
| DescriptorInstantiation_test_06     |   pass  |                                |             |  34.134  |
| DescriptorInstantiation_test_07     |   pass  |                                |             |  34.784  |
| DescriptorInstantiation_test_01     |   pass  |                                |             |  27.421  |
| DescriptorInstantiation_test_02     |   pass  |                                |             |  30.805  |
| DescriptorInstantiation_test_03     |   pass  |                                |             |  31.956  |
| DescriptorInstantiation_test_05     |   pass  |                                |             |  27.417  |
| DescriptorInstantiation_test_22     |   pass  |                                |             |  43.845  |
| GenericAttributeService_test_01     |   pass  |                                |             |  14.568  |
| ServiceInstantiation_test_13        |   pass  |                                |             |  31.028  |
| ServiceInstantiation_test_14        |   pass  |                                |             |  17.936  |
| ServiceInstantiation_test_15        |   pass  |                                |             |  18.46   |
| ServiceInstantiation_test_09        |   pass  |                                |             |  17.394  |
| ServiceInstantiation_test_08        |   pass  |                                |             |  16.988  |
| ServiceInstantiation_test_07        |   pass  |                                |             |  27.177  |
| ServiceInstantiation_test_06        |   pass  |                                |             |  27.572  |
| ServiceInstantiation_test_05        |   pass  |                                |             |  16.871  |
| ServiceInstantiation_test_04        |   pass  |                                |             |  23.362  |
| ServiceInstantiation_test_03        |   pass  |                                |             |  23.243  |
| ServiceInstantiation_test_02        |   pass  |                                |             |  15.645  |
| ServiceInstantiation_test_01        |   pass  |                                |             |  14.204  |
| ServiceInstantiation_test_30        |   pass  |                                |             |  28.575  |
| ServiceInstantiation_test_21        |   pass  |                                |             |  23.484  |
| ServiceInstantiation_test_31        |   pass  |                                |             |  36.249  |
| ServiceInstantiation_test_25        |   pass  |                                |             |  33.635  |
| ServiceInstantiation_test_18        |   pass  |                                |             |  33.373  |
| ServiceInstantiation_test_28        |   pass  |                                |             |  28.604  |
| ServiceInstantiation_test_19        |   pass  |                                |             |  35.042  |
| ServiceInstantiation_test_27        |   pass  |                                |             |  24.698  |
| ServiceInstantiation_test_26        |   pass  |                                |             |  20.744  |
| ServiceInstantiation_test_20        |   pass  |                                |             |  19.61   |
| ServiceInstantiation_test_23        |   pass  |                                |             |  33.72   |
| ServiceInstantiation_test_24        |   pass  |                                |             |  26.005  |
| ServiceInstantiation_test_10        |   pass  |                                |             |  29.417  |
| ServiceInstantiation_test_11        |   pass  |                                |             |  31.123  |
| ServiceInstantiation_test_12        |   pass  |                                |             |  29.357  |
| ServiceInstantiation_test_16        |   pass  |                                |             |  33.485  |
| ServiceInstantiation_test_17        |   pass  |                                |             |  35.11   |
| ServiceInstantiation_test_22        |   pass  |                                |             |  25.976  |
| ServiceInstantiation_test_29        |   pass  |                                |             |  36.159  |
| ibeacon                             |   pass  |                                |             |  10.691  |
+-------------------------------------+---------+--------------------------------+-------------+----------+
+---------------+----------------+
|    Summary    |                |
+---------------+----------------+
| Final Verdict |      FAIL      |
|     count     |      148       |
|      pass     |      130       |
|      fail     |       18       |
|    Duration   | 1:49:15.041000 |
+---------------+----------------+
```

Beside unimplemented features: 
- privacy
- whitelisting

everything work better than ever.
