### PR TITLE
FIX discovery process termination.

### DIFF
--- a/source/BlueNRGGattClient.cpp
+++ b/source/BlueNRGGattClient.cpp
@@ -259,10 +259,7 @@ ble_error_t BlueNRGGattClient::launchServiceDiscovery(Gap::Handle_t             
   BlueNRGGattConnectionClient *gattConnectionClient = getGattConnectionClient(connectionHandle);
 
   if(gattConnectionClient != NULL) {
-    gattConnectionClient->onServiceDiscoveryTermination(terminationCallback);
-
     return gattConnectionClient->launchServiceDiscovery(sc, cc, matchingServiceUUID, matchingCharacteristicUUIDIn);
-
   } else {
     return BLE_ERROR_INTERNAL_STACK_FAILURE;
   }

--- a/source/BlueNRGGattClient.cpp
+++ b/source/BlueNRGGattClient.cpp
@@ -314,6 +314,15 @@ void BlueNRGGattClient::terminateServiceDiscovery(void)
   }
 }
 
+void BlueNRGGattClient::onServiceDiscoveryTermination(ServiceDiscovery::TerminationCallback_t callback) {
+  terminationCallback = callback;
+  for (uint8_t i = 0; i < MAX_ACTIVE_CONNECTIONS; ++i) {
+    if (_connectionPool[i]) { 
+      _connectionPool[i]->onServiceDiscoveryTermination(callback);
+    }
+  }
+}
+
 ble_error_t BlueNRGGattClient::read(Gap::Handle_t connHandle, GattAttribute::Handle_t attributeHandle, uint16_t offset) const
 {
   BlueNRGGattConnectionClient *gattConnectionClient = const_cast<BlueNRGGattClient*>(this)->getGattConnectionClient(connHandle);

--- a/x-nucleo-idb0xa1/BlueNRGGattClient.h
+++ b/x-nucleo-idb0xa1/BlueNRGGattClient.h
@@ -80,12 +80,7 @@ public:
 
     virtual bool isServiceDiscoveryActive(void) const;
     virtual void terminateServiceDiscovery(void);
-    virtual void onServiceDiscoveryTermination(ServiceDiscovery::TerminationCallback_t callback) {
-      terminationCallback = callback;
-      for (uint8_t i = 0; i < _numConnections; ++i) {
-        _connectionPool[i]->onServiceDiscoveryTermination(callback);
-      }
-    }
+    virtual void onServiceDiscoveryTermination(ServiceDiscovery::TerminationCallback_t callback);
     virtual ble_error_t read(Gap::Handle_t connHandle, GattAttribute::Handle_t attributeHandle, uint16_t offset) const;
     virtual ble_error_t write(GattClient::WriteOp_t    cmd,
                               Gap::Handle_t            connHandle,

--- a/x-nucleo-idb0xa1/BlueNRGGattClient.h
+++ b/x-nucleo-idb0xa1/BlueNRGGattClient.h
@@ -82,6 +82,9 @@ public:
     virtual void terminateServiceDiscovery(void);
     virtual void onServiceDiscoveryTermination(ServiceDiscovery::TerminationCallback_t callback) {
       terminationCallback = callback;
+      for (uint8_t i = 0; i < _numConnections; ++i) {
+        _connectionPool[i]->onServiceDiscoveryTermination(callback);
+      }
     }
     virtual ble_error_t read(Gap::Handle_t connHandle, GattAttribute::Handle_t attributeHandle, uint16_t offset) const;
     virtual ble_error_t write(GattClient::WriteOp_t    cmd,


### PR DESCRIPTION
When the termination callback was changed or set during the discovery process
then the client would never call the updated callback at the end of the discovery.

This patch solve this issue by forcing an update of the discovery termination
callback of all client whenever it is set.