### PR TITLE
Fix connection client iteration

### DIFF
--- a/source/BlueNRGGattClient.cpp
+++ b/source/BlueNRGGattClient.cpp
@@ -300,8 +300,10 @@ bool BlueNRGGattClient::isServiceDiscoveryActive(void) const
 {
   bool isSDActive = false;
 
-  for (uint8_t i = 0; i < _numConnections; i++) {
-    isSDActive |= _connectionPool[i]->isServiceDiscoveryActive();
+  for (uint8_t i = 0; i < MAX_ACTIVE_CONNECTIONS; i++) {
+    if (_connectionPool[i]) { 
+      isSDActive |= _connectionPool[i]->isServiceDiscoveryActive();
+    }
   }
 
   return isSDActive;
@@ -309,8 +311,10 @@ bool BlueNRGGattClient::isServiceDiscoveryActive(void) const
 
 void BlueNRGGattClient::terminateServiceDiscovery(void)
 {
-  for (uint8_t i = 0; i < _numConnections; i++) {
-    _connectionPool[i]->terminateServiceDiscovery();
+  for (uint8_t i = 0; i < MAX_ACTIVE_CONNECTIONS; i++) {
+    if (_connectionPool[i]) { 
+      _connectionPool[i]->terminateServiceDiscovery();
+    }
   }
 }
 

--- a/source/BlueNRGGattClient.cpp
+++ b/source/BlueNRGGattClient.cpp
@@ -259,10 +259,7 @@ ble_error_t BlueNRGGattClient::launchServiceDiscovery(Gap::Handle_t             
   BlueNRGGattConnectionClient *gattConnectionClient = getGattConnectionClient(connectionHandle);
 
   if(gattConnectionClient != NULL) {
-    gattConnectionClient->onServiceDiscoveryTermination(terminationCallback);
-
     return gattConnectionClient->launchServiceDiscovery(sc, cc, matchingServiceUUID, matchingCharacteristicUUIDIn);
-
   } else {
     return BLE_ERROR_INTERNAL_STACK_FAILURE;
   }

--- a/source/BlueNRGGattClient.cpp
+++ b/source/BlueNRGGattClient.cpp
@@ -314,6 +314,15 @@ void BlueNRGGattClient::terminateServiceDiscovery(void)
   }
 }
 
+void BlueNRGGattClient::onServiceDiscoveryTermination(ServiceDiscovery::TerminationCallback_t callback) {
+  terminationCallback = callback;
+  for (uint8_t i = 0; i < MAX_ACTIVE_CONNECTIONS; ++i) {
+    if (_connectionPool[i]) { 
+      _connectionPool[i]->onServiceDiscoveryTermination(callback);
+    }
+  }
+}
+
 ble_error_t BlueNRGGattClient::read(Gap::Handle_t connHandle, GattAttribute::Handle_t attributeHandle, uint16_t offset) const
 {
   BlueNRGGattConnectionClient *gattConnectionClient = const_cast<BlueNRGGattClient*>(this)->getGattConnectionClient(connHandle);

--- a/x-nucleo-idb0xa1/BlueNRGGattClient.h
+++ b/x-nucleo-idb0xa1/BlueNRGGattClient.h
@@ -80,12 +80,7 @@ public:
 
     virtual bool isServiceDiscoveryActive(void) const;
     virtual void terminateServiceDiscovery(void);
-    virtual void onServiceDiscoveryTermination(ServiceDiscovery::TerminationCallback_t callback) {
-      terminationCallback = callback;
-      for (uint8_t i = 0; i < _numConnections; ++i) {
-        _connectionPool[i]->onServiceDiscoveryTermination(callback);
-      }
-    }
+    virtual void onServiceDiscoveryTermination(ServiceDiscovery::TerminationCallback_t callback);
     virtual ble_error_t read(Gap::Handle_t connHandle, GattAttribute::Handle_t attributeHandle, uint16_t offset) const;
     virtual ble_error_t write(GattClient::WriteOp_t    cmd,
                               Gap::Handle_t            connHandle,

--- a/x-nucleo-idb0xa1/BlueNRGGattClient.h
+++ b/x-nucleo-idb0xa1/BlueNRGGattClient.h
@@ -82,6 +82,9 @@ public:
     virtual void terminateServiceDiscovery(void);
     virtual void onServiceDiscoveryTermination(ServiceDiscovery::TerminationCallback_t callback) {
       terminationCallback = callback;
+      for (uint8_t i = 0; i < _numConnections; ++i) {
+        _connectionPool[i]->onServiceDiscoveryTermination(callback);
+      }
     }
     virtual ble_error_t read(Gap::Handle_t connHandle, GattAttribute::Handle_t attributeHandle, uint16_t offset) const;
     virtual ble_error_t write(GattClient::WriteOp_t    cmd,


### PR DESCRIPTION
This PR depends on #18. 

It fix the forwarding of isServiceDiscoveryActive and terminateServiceDiscovery to clients to the actual clients.

The previous code was just forwarding the function to the first _numClient. This
would work if clients the connection pool are accessible sequentially unfortunatelly
it is not the case.

With this fix the entirety of the connection pool is traversed and if a client is
present then the action is forwarded.