### PR TITLE
Fix invalid copy of Timeout objects.

### DIFF
--- a/bluenrg/BlueNRGGap.h
+++ b/bluenrg/BlueNRGGap.h
@@ -140,7 +140,7 @@ public:
     bool getIsSetAddress();
 
     // ADV timeout handling
-    Timeout getAdvTimeout(void) const {
+    Timeout& getAdvTimeout(void) {
         return advTimeout;
     }
     uint8_t getAdvToFlag(void) {
@@ -149,7 +149,7 @@ public:
     void setAdvToFlag(void);
 
     // SCAN timeout handling
-    Timeout getScanTimeout(void) const {
+    Timeout& getScanTimeout(void) {
         return scanTimeout;
     }
     uint8_t getScanToFlag(void) {

--- a/source/BlueNRGGap.cpp
+++ b/source/BlueNRGGap.cpp
@@ -215,7 +215,7 @@ static void advTimeoutCB(void)
 {
     BlueNRGGap::getInstance().setAdvToFlag();
 
-    Timeout t = BlueNRGGap::getInstance().getAdvTimeout();
+    Timeout& t = BlueNRGGap::getInstance().getAdvTimeout();
     t.detach(); /* disable the callback from the timeout */
 }
 #endif /* AST_FOR_MBED_OS */
@@ -232,7 +232,7 @@ static void scanTimeoutCB(void)
 {
     BlueNRGGap::getInstance().setScanToFlag();
 
-    Timeout t = BlueNRGGap::getInstance().getScanTimeout();
+    Timeout& t = BlueNRGGap::getInstance().getScanTimeout();
     t.detach(); /* disable the callback from the timeout */
 }
 


### PR DESCRIPTION
By definition Timeout objects are not value types, they have an identity.
Due to the lack of protection against copy, those objects were copied in
BlueNRGGap.